### PR TITLE
Add missing angular-moment dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "angular-local-storage": "~0.2.3",
     "angular-socket-io": "~0.7.0",
-    "sio-client": "~1.3.6"
+    "sio-client": "~1.3.6",
+    "angular-moment": "~0.9.2",
+    "moment": "2.9.0"
   }
 }


### PR DESCRIPTION
This repository is missing the angular-moment dependency as indicated in article https://www.sitepoint.com/using-socket-io-and-cordova-to-create-a-real-time-chat-app/, failing when boot angular. So i add the correct bower.json.
